### PR TITLE
feat(deploy): add manifest-based diff deploy via deploy.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,110 @@
 
 The production build process (`server_build_script.sh`) requires a Docker image called `cyberknight-council-template-builder`. This image contains Ruby, Jekyll, and all necessary dependencies.
 
-From within the project directory run the following to build it: `docker build -t cyberknight-council-template-builder .` 
+From within the project directory run the following to build it: `docker build -t cyberknight-council-template-builder .`
+
+---
+
+## Build and Deploy
+
+### `server_build_script.sh` — full pipeline (clone → data sync → build → deploy)
+
+Intended for production use. Clones a fresh copy of the repository, syncs council data, builds the Jekyll site via Docker, and deploys to S3 with Cloudflare cache purge.
+
+```bash
+sudo ./server_build_script.sh \
+  COUNCIL_NUMBER=2431 \
+  JEKYLL_DIR=/tmp/council-2431-build \
+  JEKYLL_BUILDER_IMAGE=cyberknight-council-template-builder \
+  NGINX_DIR=/var/www/nginx
+```
+
+**Arguments (all `KEY=VALUE` style):**
+- `COUNCIL_NUMBER` — council number (e.g. `2431`). Determines the S3 folder and Cloudflare hostname.
+- `JEKYLL_DIR` — directory used for the git clone and Jekyll build.
+- `JEKYLL_BUILDER_IMAGE` — name of the Docker image used for building.
+- `NGINX_DIR` — accepted for backward compatibility with webhook callers; not used for deployment (site goes to S3).
+
+**Optional:**
+- `FORCE_FULL=true` — skip the manifest diff and re-upload all files regardless of what changed.
+
+```bash
+sudo ./server_build_script.sh COUNCIL_NUMBER=2431 JEKYLL_DIR=/tmp/council-2431-build \
+  JEKYLL_BUILDER_IMAGE=cyberknight-council-template-builder NGINX_DIR=/ FORCE_FULL=true
+```
+
+Logs are written to `/home/julian/logs/cyberknight-council-template/build_TIMESTAMP.log` (or `./logs/` if that directory is not writable).
+
+---
+
+### `deploy.sh` — deploy only (no clone or build)
+
+Deploys an existing `JEKYLL_DIR/_site/` directory to S3 using a manifest-based diff — only files that have changed since the last deploy are uploaded or deleted. Purges only the affected URLs from Cloudflare's cache.
+
+```bash
+sudo ./deploy.sh \
+  COUNCIL_NUMBER=2431 \
+  JEKYLL_DIR=/tmp/council-2431-build \
+  JEKYLL_BUILDER_IMAGE=cyberknight-council-template-builder \
+  NGINX_DIR=/
+```
+
+**Arguments (all `KEY=VALUE` style):**
+- `COUNCIL_NUMBER` — **(required)** council number. Drives the S3 folder (`council-<N>/`), manifest path (`council-<N>/.manifest.json`), and Cloudflare purge hostname (`council-<N>.cyberknight-websites.com`).
+- `JEKYLL_DIR` — **(required)** path to the directory containing `_site/`.
+- `JEKYLL_BUILDER_IMAGE` — **(required)** Docker image name (accepted but not used by deploy.sh itself).
+- `NGINX_DIR` — accepted for interface compatibility; not used for deployment.
+
+**Optional:**
+- `FORCE_FULL=true` — skip the manifest diff and re-upload all files, regenerating the manifest from scratch.
+
+```bash
+sudo ./deploy.sh COUNCIL_NUMBER=2431 JEKYLL_DIR=/tmp/council-2431-build \
+  JEKYLL_BUILDER_IMAGE=cyberknight-council-template-builder NGINX_DIR=/ FORCE_FULL=true
+```
+
+**Dry-run invocation (for isolated testing):**
+
+```bash
+mkdir -p /tmp/cyberknight-dry-run/_site
+echo "<html><body>Test</body></html>" > /tmp/cyberknight-dry-run/_site/index.html
+
+DOPPLER_TOKEN="<token>" sudo -E ./deploy.sh \
+  JEKYLL_DIR=/tmp/cyberknight-dry-run \
+  COUNCIL_NUMBER=2431 \
+  JEKYLL_BUILDER_IMAGE=cyberknight-council-template-builder \
+  NGINX_DIR=/
+```
+
+**Requirements:** must be run as root. Requires `aws`, `doppler`, `jq`, `sha256sum`, `curl`, `pass`, and `perl` in PATH, and the `cyberknight/s3-sync-doppler-token` key in the root `pass` store (or `DOPPLER_TOKEN` pre-set in the environment).
+
+Logs are written to `~/logs/cyberknight-council-template/deploy_TIMESTAMP.log` (or `./logs/` if that directory is not writable).
+
+---
+
+## Infrastructure
+
+- **S3 bucket:** `cyberknight-websites`, folder `council-<COUNCIL_NUMBER>/`
+- **Cloudflare zone:** `council-<COUNCIL_NUMBER>.cyberknight-websites.com`
+- **Credentials:** managed via Doppler project `cyberknight-s3-sync`, config `prd`
+- **Manifest:** stored at `s3://cyberknight-websites/council-<COUNCIL_NUMBER>/.manifest.json`
+- **CF purge chunk size:** 100 URLs per request (plan limit for this zone; the corporate zone uses 500)
+
+---
+
+## Argument style asymmetry vs corporate website
+
+The corporate website (`cyberknight-corporate-website`) uses `--flag` style arguments:
+
+```bash
+./deploy.sh --force-full          # corporate
+./build_www.sh --force-full       # corporate
+```
+
+The council template uses `KEY=VALUE` style, consistent with `server_build_script.sh`:
+
+```bash
+./deploy.sh ... FORCE_FULL=true   # council
+```
+
+This is intentional — the council webhook caller already uses `KEY=VALUE` for all arguments, so `deploy.sh` follows the same convention. Future maintainers: do not switch council scripts to `--flag` style without also updating the webhook caller.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,458 @@
+#!/bin/bash
+
+# Deploy _site/ to S3 + Cloudflare cache purge (manifest-based diff deploy)
+# Usage: ./deploy.sh COUNCIL_NUMBER=<n> JEKYLL_DIR=<path> JEKYLL_BUILDER_IMAGE=<img> NGINX_DIR=<path> [FORCE_FULL=true]
+#
+# Credentials are injected via Doppler (cyberknight-s3-sync / prd).
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+get_timestamp() {
+  perl -MTime::HiRes=time -e 'printf "%.2f", time'
+}
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+if [ -w "$HOME/logs" ]; then
+  LOG_DIR="$HOME/logs/cyberknight-council-template"
+else
+  LOG_DIR="./logs"
+fi
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+LOG_FILE="$LOG_DIR/deploy_${TIMESTAMP}.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+START_TIME=$(get_timestamp)
+echo "=== Deploy started at $(date) ==="
+
+# ---------------------------------------------------------------------------
+# Temporary file tracking for cleanup
+# ---------------------------------------------------------------------------
+
+TEMP_FILES=()
+
+cleanup() {
+  local exit_code=$?
+  for f in "${TEMP_FILES[@]}"; do
+    rm -f "$f"
+  done
+  exit $exit_code
+}
+
+trap cleanup EXIT
+
+add_temp() {
+  local tmpfile
+  tmpfile=$(mktemp)
+  TEMP_FILES+=("$tmpfile")
+  echo "$tmpfile"
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Argument parsing
+# ---------------------------------------------------------------------------
+
+FORCE_FULL=false
+
+for arg in "$@"; do
+  case "$arg" in
+    *=*)
+      varname=$(echo "$arg" | cut -d= -f1)
+      varvalue=$(echo "$arg" | cut -d= -f2-)
+      eval "$varname=\"$varvalue\""
+      ;;
+    *)
+      echo "ERROR: Unknown argument '$arg'. Expected KEY=VALUE format."
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+arg_errors=()
+if [ -z "$COUNCIL_NUMBER" ]; then
+  arg_errors+=("COUNCIL_NUMBER is required")
+fi
+if [ -z "$JEKYLL_DIR" ]; then
+  arg_errors+=("JEKYLL_DIR is required")
+fi
+if [ -z "$JEKYLL_BUILDER_IMAGE" ]; then
+  arg_errors+=("JEKYLL_BUILDER_IMAGE is required")
+fi
+if [ -z "$NGINX_DIR" ]; then
+  echo "WARNING: NGINX_DIR is not set. This is expected — deployment goes to S3."
+fi
+
+if [ ${#arg_errors[@]} -gt 0 ]; then
+  echo "ERROR: Missing required arguments:"
+  for e in "${arg_errors[@]}"; do
+    echo "  - $e"
+  done
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Dependency checks
+# ---------------------------------------------------------------------------
+
+check_dependencies() {
+  local failures=()
+
+  # aws
+  if ! command -v aws &>/dev/null; then
+    failures+=("aws — binary not found in PATH")
+  fi
+
+  # doppler
+  if ! command -v doppler &>/dev/null; then
+    failures+=("doppler — binary not found in PATH")
+  fi
+
+  # jq
+  if ! command -v jq &>/dev/null; then
+    failures+=("jq — binary not found in PATH")
+  fi
+
+  # sha256sum
+  if ! command -v sha256sum &>/dev/null; then
+    failures+=("sha256sum — binary not found in PATH")
+  fi
+
+  # curl
+  if ! command -v curl &>/dev/null; then
+    failures+=("curl — binary not found in PATH")
+  fi
+
+  # pass
+  if ! command -v pass &>/dev/null; then
+    failures+=("pass — binary not found in PATH")
+  fi
+
+  # perl
+  if ! command -v perl &>/dev/null; then
+    failures+=("perl — binary not found in PATH")
+  fi
+
+  # Only check pass key and Doppler accessibility if DOPPLER_TOKEN is not already set
+  if [ -z "$DOPPLER_TOKEN" ]; then
+    local pass_token_check
+    pass_token_check=$(pass show cyberknight/s3-sync-doppler-token 2>/dev/null) || true
+    if [ -z "$pass_token_check" ]; then
+      failures+=("pass key cyberknight/s3-sync-doppler-token is not accessible (missing GPG key or uninitialized password store?)")
+    fi
+
+    local doppler_token_check
+    doppler_token_check=$(DOPPLER_TOKEN="$pass_token_check" doppler secrets get CLOUDFLARE_API_TOKEN --project cyberknight-s3-sync --config prd --plain 2>/dev/null) || true
+    if [ -z "$doppler_token_check" ]; then
+      failures+=("Doppler project cyberknight-s3-sync / prd is not accessible or CLOUDFLARE_API_TOKEN is missing")
+    fi
+  fi
+
+  if [ ${#failures[@]} -gt 0 ]; then
+    echo "ERROR: The following dependency checks failed:"
+    for f in "${failures[@]}"; do
+      echo "  - $f"
+    done
+    exit 1
+  fi
+}
+
+check_dependencies
+
+# ---------------------------------------------------------------------------
+# Step 3: Configuration
+# ---------------------------------------------------------------------------
+
+S3_BUCKET="cyberknight-websites"
+S3_FOLDER="council-${COUNCIL_NUMBER}"
+SITE_DIR="${JEKYLL_DIR}/_site"
+MANIFEST_KEY="${S3_FOLDER}/.manifest.json"
+CF_ZONE_ID="9dbd179caf99bb5fd469db1545fbb431"
+CF_HOSTNAME="council-${COUNCIL_NUMBER}.cyberknight-websites.com"
+CF_PURGE_CHUNK_SIZE=100
+MAX_PARALLEL_UPLOADS=8
+
+echo "Deploying council: $COUNCIL_NUMBER"
+echo "JEKYLL_DIR: $JEKYLL_DIR"
+echo "S3 folder: s3://${S3_BUCKET}/${S3_FOLDER}/"
+echo "CF hostname: $CF_HOSTNAME"
+
+# ---------------------------------------------------------------------------
+# Step 4: Doppler token
+# ---------------------------------------------------------------------------
+
+if [ -z "$DOPPLER_TOKEN" ]; then
+  export DOPPLER_TOKEN="$(pass show cyberknight/s3-sync-doppler-token)"
+  if [ -z "$DOPPLER_TOKEN" ]; then
+    echo "ERROR: Could not retrieve Doppler token from pass. Exiting."
+    exit 1
+  fi
+fi
+
+if [ ! -d "$SITE_DIR" ]; then
+  echo "ERROR: Site directory '${SITE_DIR}' not found. Run a Jekyll build first."
+  exit 1
+fi
+
+export AWS_ACCESS_KEY_ID=$(doppler secrets get AWS_ACCESS_KEY_ID --project cyberknight-s3-sync --config prd --plain)
+export AWS_SECRET_ACCESS_KEY=$(doppler secrets get AWS_SECRET_ACCESS_KEY --project cyberknight-s3-sync --config prd --plain)
+
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "ERROR: Could not retrieve AWS credentials from Doppler. Exiting."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Fetch previous manifest
+# ---------------------------------------------------------------------------
+
+PREV_MANIFEST_FILE=$(add_temp)
+FULL_UPLOAD=false
+
+STEP_START=$(get_timestamp)
+if ! aws s3 cp "s3://${S3_BUCKET}/${MANIFEST_KEY}" "$PREV_MANIFEST_FILE" --region us-east-1 2>/dev/null; then
+  echo "No previous manifest found in S3. Performing full upload."
+  FULL_UPLOAD=true
+fi
+
+PREV_FETCH_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+
+if [ "$FORCE_FULL" = true ]; then
+  FULL_UPLOAD=true
+  echo "Full upload forced via FORCE_FULL=true flag."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Generate current manifest
+# ---------------------------------------------------------------------------
+
+STEP_START=$(get_timestamp)
+CURRENT_MANIFEST_FILE=$(add_temp)
+
+# Build JSON object: { "relative/path": "sha256hash", ... }
+MANIFEST_JSON="{}"
+
+while IFS= read -r -d '' file; do
+  rel_path="${file#${SITE_DIR}/}"
+  hash=$(sha256sum "$file" | awk '{print $1}')
+  MANIFEST_JSON=$(echo "$MANIFEST_JSON" | jq --arg key "$rel_path" --arg val "$hash" '. + {($key): $val}')
+done < <(find "$SITE_DIR" -type f -print0 | sort -z)
+
+echo "$MANIFEST_JSON" > "$CURRENT_MANIFEST_FILE"
+HASH_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+
+# ---------------------------------------------------------------------------
+# Step 7: Diff the manifests
+# ---------------------------------------------------------------------------
+
+STEP_START=$(get_timestamp)
+
+if [ "$FULL_UPLOAD" = true ]; then
+  ADDED_MODIFIED_FILE=$(add_temp)
+  jq -r 'keys[]' "$CURRENT_MANIFEST_FILE" | sort > "$ADDED_MODIFIED_FILE"
+  ADDED_COUNT=$(wc -l < "$ADDED_MODIFIED_FILE")
+
+  DELETED_FILE=$(add_temp)
+  : > "$DELETED_FILE"
+  DELETED_COUNT=0
+
+  UNCHANGED_COUNT=0
+else
+  ADDED_MODIFIED_FILE=$(add_temp)
+  DELETED_FILE=$(add_temp)
+  UNCHANGED_FILE=$(add_temp)
+
+  jq -rn --slurpfile prev "$PREV_MANIFEST_FILE" --slurpfile curr "$CURRENT_MANIFEST_FILE" '
+    ($prev[0] // {}) as $p |
+    ($curr[0]) as $c |
+    [$c | keys[] | . as $k | select(($p[$k] // null) != $c[$k])] |
+    sort |
+    .[]
+  ' > "$ADDED_MODIFIED_FILE"
+
+  jq -rn --slurpfile prev "$PREV_MANIFEST_FILE" --slurpfile curr "$CURRENT_MANIFEST_FILE" '
+    ($prev[0] // {}) as $p |
+    ($curr[0]) as $c |
+    [$p | keys[] | . as $k | select(($c[$k] // null) == null)] |
+    sort |
+    .[]
+  ' > "$DELETED_FILE"
+
+  jq -n --slurpfile prev "$PREV_MANIFEST_FILE" --slurpfile curr "$CURRENT_MANIFEST_FILE" '
+    ($prev[0] // {}) as $p |
+    ($curr[0]) as $c |
+    [$c | keys[] | . as $k | select($p[$k] == $c[$k])] |
+    length
+  ' > "$UNCHANGED_FILE"
+
+  ADDED_COUNT=$(wc -l < "$ADDED_MODIFIED_FILE")
+  DELETED_COUNT=$(wc -l < "$DELETED_FILE")
+  UNCHANGED_COUNT=$(cat "$UNCHANGED_FILE")
+fi
+
+DIFF_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+
+echo "Manifest diff: ${ADDED_COUNT} added/modified, ${DELETED_COUNT} deleted, ${UNCHANGED_COUNT} unchanged"
+
+if [ "$ADDED_COUNT" -eq 0 ] && [ "$DELETED_COUNT" -eq 0 ]; then
+  echo "Nothing to deploy. Exiting."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Upload changed files
+# ---------------------------------------------------------------------------
+
+STEP_START=$(get_timestamp)
+
+echo "Uploading ${ADDED_COUNT} file(s) to S3..."
+upload_pids=()
+upload_failed=false
+
+while IFS= read -r rel_path; do
+  aws s3 cp "${SITE_DIR}/${rel_path}" "s3://${S3_BUCKET}/${S3_FOLDER}/${rel_path}" --region us-east-1 &
+  upload_pids+=($!)
+  if [ ${#upload_pids[@]} -ge "$MAX_PARALLEL_UPLOADS" ]; then
+    wait "${upload_pids[0]}" || upload_failed=true
+    upload_pids=("${upload_pids[@]:1}")
+  fi
+done < "$ADDED_MODIFIED_FILE"
+
+for pid in "${upload_pids[@]}"; do
+  wait "$pid" || upload_failed=true
+done
+
+if [ "$upload_failed" = true ]; then
+  echo "ERROR: One or more uploads failed. Exiting."
+  exit 1
+fi
+
+UPLOAD_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+echo "  → S3 uploads complete in ${UPLOAD_TIME}s"
+
+# Delete removed files
+STEP_START=$(get_timestamp)
+
+if [ "$DELETED_COUNT" -gt 0 ]; then
+  echo "Deleting ${DELETED_COUNT} file(s) from S3..."
+  delete_pids=()
+  delete_failed=false
+
+  while IFS= read -r rel_path; do
+    aws s3 rm "s3://${S3_BUCKET}/${S3_FOLDER}/${rel_path}" --region us-east-1 &
+    delete_pids+=($!)
+    if [ ${#delete_pids[@]} -ge "$MAX_PARALLEL_UPLOADS" ]; then
+      wait "${delete_pids[0]}" || delete_failed=true
+      delete_pids=("${delete_pids[@]:1}")
+    fi
+  done < "$DELETED_FILE"
+
+  for pid in "${delete_pids[@]}"; do
+    wait "$pid" || delete_failed=true
+  done
+
+  if [ "$delete_failed" = true ]; then
+    echo "ERROR: One or more deletes failed. Exiting."
+    exit 1
+  fi
+fi
+
+DELETE_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+echo "  → S3 deletes complete in ${DELETE_TIME}s"
+
+# ---------------------------------------------------------------------------
+# Step 9: Update the manifest in S3
+# ---------------------------------------------------------------------------
+
+STEP_START=$(get_timestamp)
+echo "Updating manifest in S3..."
+aws s3 cp "$CURRENT_MANIFEST_FILE" "s3://${S3_BUCKET}/${MANIFEST_KEY}" --region us-east-1
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to update manifest in S3. Exiting."
+  echo "WARNING: The next build will diff against stale state. Consider running with FORCE_FULL=true on the next deploy."
+  exit 1
+fi
+
+MANIFEST_WRITE_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+echo "  → Manifest updated in ${MANIFEST_WRITE_TIME}s"
+
+# ---------------------------------------------------------------------------
+# Step 10: Purge Cloudflare cache
+# ---------------------------------------------------------------------------
+
+STEP_START=$(get_timestamp)
+echo "Purging Cloudflare cache..."
+
+CF_TOKEN=$(doppler secrets get CLOUDFLARE_API_TOKEN --project cyberknight-s3-sync --config prd --plain)
+
+CHANGED_URLS_FILE=$(add_temp)
+: > "$CHANGED_URLS_FILE"
+
+while IFS= read -r rel_path; do
+  echo "https://${CF_HOSTNAME}/${rel_path}" >> "$CHANGED_URLS_FILE"
+done < "$ADDED_MODIFIED_FILE"
+
+while IFS= read -r rel_path; do
+  echo "https://${CF_HOSTNAME}/${rel_path}" >> "$CHANGED_URLS_FILE"
+done < "$DELETED_FILE"
+
+TOTAL_CHANGED=$(wc -l < "$CHANGED_URLS_FILE")
+NUM_CHUNKS=$(( (TOTAL_CHANGED + CF_PURGE_CHUNK_SIZE - 1) / CF_PURGE_CHUNK_SIZE ))
+
+PURGE_FAILED=false
+for (( i=0; i<NUM_CHUNKS; i++ )); do
+  CHUNK_START=$((i * CF_PURGE_CHUNK_SIZE))
+  CHUNK_END=$((CHUNK_START + CF_PURGE_CHUNK_SIZE))
+
+  CHUNK_JSON=$(sed -n "$((CHUNK_START + 1)),$((CHUNK_END))p" "$CHANGED_URLS_FILE" | jq -R . | jq -s .)
+
+  PURGE_RESPONSE_FILE=$(add_temp)
+
+  HTTP_CODE=$(curl -s -o "$PURGE_RESPONSE_FILE" -w "%{http_code}" \
+    -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+    -H "Authorization: Bearer ${CF_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "{\"files\": ${CHUNK_JSON}}")
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo "ERROR: Cloudflare cache purge returned HTTP ${HTTP_CODE}."
+    cat "$PURGE_RESPONSE_FILE" >&2
+    PURGE_FAILED=true
+  fi
+done
+
+PURGE_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+
+if [ "$PURGE_FAILED" = true ]; then
+  echo "ERROR: Cloudflare cache purge failed. Exiting."
+  exit 1
+fi
+
+echo "  → Cache purge complete in ${PURGE_TIME}s"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+END_TIME=$(get_timestamp)
+DURATION=$(perl -e "printf '%.2f', $END_TIME - $START_TIME")
+
+echo ""
+echo "=== Deploy completed at $(date) ==="
+echo "=== Total deploy time: ${DURATION}s ==="
+echo ""
+echo "Step-by-step breakdown:"
+echo "  1. Manifest fetch:     ${PREV_FETCH_TIME}s"
+echo "  2. Hashing:            ${HASH_TIME}s"
+echo "  3. Diff:               ${DIFF_TIME}s"
+echo "  4. S3 uploads:         ${UPLOAD_TIME}s"
+echo "  5. S3 deletes:         ${DELETE_TIME}s"
+echo "  6. Manifest write:     ${MANIFEST_WRITE_TIME}s"
+echo "  7. Cache purge:        ${PURGE_TIME}s"

--- a/server_build_script.sh
+++ b/server_build_script.sh
@@ -23,6 +23,9 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 START_TIME=$(get_timestamp)
 echo "=== Build started at $(date) ==="
 
+FORCE_FULL=false
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # parse arguments KEY=VALUE
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -61,7 +64,13 @@ echo "JEKYLL_BUILDER_IMAGE: $JEKYLL_BUILDER_IMAGE"
 
 # --- Doppler secrets ---
 export HISTIGNORE='export DOPPLER_TOKEN*'
-export DOPPLER_TOKEN="$(pass show cyberknight/s3-sync-doppler-token)"
+if [ -z "$DOPPLER_TOKEN" ]; then
+  export DOPPLER_TOKEN="$(pass show cyberknight/s3-sync-doppler-token)"
+  if [ -z "$DOPPLER_TOKEN" ]; then
+    echo "ERROR: Could not retrieve Doppler token from pass. Exiting."
+    exit 1
+  fi
+fi
 
 # Remove JEKYLL_DIR if it exists and create a new one
 STEP_START=$(get_timestamp)
@@ -105,31 +114,28 @@ if [ $DOCKER_EXIT_CODE -ne 0 ]; then
   exit 1
 fi
 
-# Sync to S3
-echo "Syncing to S3..."
+# Deploy to S3 + Cloudflare (manifest-based diff deploy)
+echo "Deploying to S3..."
 STEP_START=$(get_timestamp)
-doppler run --project cyberknight-s3-sync --config prd -- \
-  aws s3 sync $JEKYLL_DIR/_site/ s3://cyberknight-websites/council-$COUNCIL_NUMBER/ --delete
-S3_EXIT_CODE=$?
-S3_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
-echo "  → S3 sync completed with exit code $S3_EXIT_CODE in ${S3_TIME}s"
-
-if [ $S3_EXIT_CODE -ne 0 ]; then
-  echo "ERROR: S3 sync failed. Site may be partially deployed."
-  exit 1
+DEPLOY_EXTRA_ARGS=""
+if [ "$FORCE_FULL" = "true" ]; then
+  DEPLOY_EXTRA_ARGS="FORCE_FULL=true"
 fi
 
-# Purge Cloudflare cache
-echo "Purging Cloudflare cache for council-$COUNCIL_NUMBER..."
-STEP_START=$(get_timestamp)
-CF_TOKEN=$(doppler secrets get CLOUDFLARE_API_TOKEN --project cyberknight-s3-sync --config prd --plain)
-CF_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-  "https://api.cloudflare.com/client/v4/zones/9dbd179caf99bb5fd469db1545fbb431/purge_cache" \
-  -H "Authorization: Bearer $CF_TOKEN" \
-  -H "Content-Type: application/json" \
-  --data "{\"prefixes\": [\"council-$COUNCIL_NUMBER.cyberknight-websites.com/\"]}")
-PURGE_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
-echo "  → Cache purge HTTP $CF_HTTP_CODE completed in ${PURGE_TIME}s"
+"$SCRIPT_DIR/deploy.sh" \
+  COUNCIL_NUMBER="$COUNCIL_NUMBER" \
+  JEKYLL_DIR="$JEKYLL_DIR" \
+  JEKYLL_BUILDER_IMAGE="$JEKYLL_BUILDER_IMAGE" \
+  NGINX_DIR="${NGINX_DIR:-}" \
+  $DEPLOY_EXTRA_ARGS
+DEPLOY_EXIT_CODE=$?
+DEPLOY_TIME=$(perl -e "printf '%.2f', $(get_timestamp) - $STEP_START")
+echo "  → Deploy completed with exit code $DEPLOY_EXIT_CODE in ${DEPLOY_TIME}s"
+
+if [ $DEPLOY_EXIT_CODE -ne 0 ]; then
+  echo "ERROR: Deploy failed. Exiting."
+  exit 1
+fi
 
 # Calculate build duration
 END_TIME=$(get_timestamp)
@@ -144,5 +150,4 @@ echo "  1. Cleanup directories:     ${CLEANUP_TIME}s"
 echo "  2. Git clone repository:    ${CLONE_TIME}s"
 echo "  3. Sync council data:       ${SYNC_TIME}s"
 echo "  4. Jekyll build:            ${BUILD_TIME}s"
-echo "  5. S3 sync:                 ${S3_TIME}s"
-echo "  6. Cloudflare cache purge:  ${PURGE_TIME}s"
+echo "  5. Deploy:                  ${DEPLOY_TIME}s"


### PR DESCRIPTION
Replaces the aws s3 sync + prefix Cloudflare purge with a content-hash manifest system. deploy.sh diffs SHA-256 hashes of _site/ against a per-council manifest stored in S3, uploads only changed files, deletes removed files, and purges only the affected URLs from Cloudflare.

server_build_script.sh now pre-fetches DOPPLER_TOKEN via pass and calls deploy.sh as a subprocess, passing COUNCIL_NUMBER, JEKYLL_DIR, JEKYLL_BUILDER_IMAGE, NGINX_DIR, and FORCE_FULL=true when requested.

Key council-specific details:
- Arguments are KEY=VALUE style (not --flags)
- S3 folder and manifest key are derived from COUNCIL_NUMBER at runtime
- Cloudflare purge chunk size is 100 (plan limit for this zone)
- FORCE_FULL=true triggers a full re-upload and manifest regeneration

Verified end-to-end against council 2431: full upload on first run, incremental diff on subsequent runs, manifest written to s3://cyberknight-websites/council-2431/.manifest.json, site loads at council-2431.cyberknight-websites.com.